### PR TITLE
Update for AWS in 2025

### DIFF
--- a/bigip/bigip-automation-guides/module_2/module_2_chapter_2/scripts/create-ecdsa-certs.sh
+++ b/bigip/bigip-automation-guides/module_2/module_2_chapter_2/scripts/create-ecdsa-certs.sh
@@ -8,10 +8,11 @@ openssl req -new -days 1 -nodes -x509 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=bigip1.f5lab.dev" \
     -key example01b.tmp.key -out example01b.tmp.cert
 
-sed -e ':a;N;$!ba; s/-\n/-\\n/g; s/\n//g; s/-----E/\\n\-----E/g' example01a.tmp.cert | head -c -1 > example01a.f5lab.dev.cert
-sed -e ':a;N;$!ba; s/-\n/-\\n/g; s/\n//g; s/-----E/\\n\-----E/g' example01a.tmp.key | head -c -1 > example01a.f5lab.dev.key
-sed -e ':a;N;$!ba; s/-\n/-\\n/g; s/\n//g; s/-----E/\\n\-----E/g' example01b.tmp.cert | head -c -1 > example01b.f5lab.dev.cert
-sed -e ':a;N;$!ba; s/-\n/-\\n/g; s/\n//g; s/-----E/\\n\-----E/g' example01b.tmp.key | head -c -1 > example01b.f5lab.dev.key
+awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' example01a.tmp.cert >example01a.f5lab.dev.cert
+awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' example01a.tmp.key >example01a.f5lab.dev.key
+awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' example01b.tmp.cert >example01b.f5lab.dev.cert
+awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' example01b.tmp.key >example01b.f5lab.dev.key
+
 
 rm example*.tmp*
 if [ $? -eq 0 ]

--- a/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/ami-search.tf
+++ b/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/ami-search.tf
@@ -15,6 +15,7 @@ data "aws_ami" "linux" {
     name   = "name"
     values = [var.linux_ami_search_name]
   }
+  owners = ["amazon"]
 }
 
 output "f5_ami_name" {

--- a/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/main.tf
+++ b/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/main.tf
@@ -12,5 +12,5 @@ terraform {
 provider "aws" {
   region                   = var.aws_region
   shared_credentials_files = ["~/.aws/credentials"]
-  profile                  = "gov"
+  profile                  = "default"
 }

--- a/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/main.tf
+++ b/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/main.tf
@@ -12,5 +12,5 @@ terraform {
 provider "aws" {
   region                   = var.aws_region
   shared_credentials_files = ["~/.aws/credentials"]
-  profile                  = "default"
+  profile                  = "gov"
 }

--- a/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/terraform.tfvars.example
+++ b/bigip/bigip-automation-guides/module_2/module_2_chapter_2/terraform/terraform.tfvars.example
@@ -64,7 +64,7 @@ bigip_netcfg = {
 }
 
 # App server variables
-linux_ami_search_name = "amzn2-ami-minimal-hvm*2023*x86*"
+linux_ami_search_name = "amzn2-ami-minimal-hvm*x86*"
 linux_instance_type   = "t2.micro"
 
 appsvr_netcfg = {


### PR DESCRIPTION
Three fixes:

1. Modify Linux AMI search filter to remove year (2023 no longer exists)
2. Add now mandatory "owners" field to Linux AMI search
3. Replace sed with awk in `create-ecdsa-certs.sh`